### PR TITLE
Add watchOS snap scoring app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# tennis123
+# SnapScore Watch App
+
+這個專案提供一個獨立的 Apple Watch 計分 App（SwiftUI + watchOS），專為網球或板網球等對戰運動設計。透過腕部 snap/外翻手勢即可完成即時記分，並且支援 HealthKit 背景執行與抬腕 Double Tap 備援。
+
+## 核心功能
+
+- **手勢計分**：利用 Core Motion 50–100 Hz 的 deviceMotion 串流，透過 `GestureEngine` 管線進行前處理、低活動期閘門、峰值偵測與雙次手勢判定。
+- **運動背景執行**：以 `HKWorkoutSession` 啟動「Workout processing」背景模式，螢幕熄滅時仍可偵測 IMU。
+- **前景備援**：主要加分按鈕標記為 Primary Action，支援 S9 / Ultra 2 的 Double Tap 喚醒後快速加分。
+- **觸覺回饋**：`HapticsManager` 依據單/雙手勢播放不同觸覺回應。
+- **資料保存**：可選擇寫入 HealthKit Workout，以及在本地容器輸出 CSV 記錄比分。
+- **個人化校準**：提供校準流程紀錄 10 組單/雙手勢，自動估算最佳閾值與低活動門檻，並支援左右手獨立參數。
+
+## 模組化架構
+
+| 模組 | 負責項目 |
+| --- | --- |
+| `MotionStream` | 管理 `CMMotionManager` 串流與取樣率設定。 |
+| `GestureEngine` | 低活動期判定、不應期管理、單雙峰判斷與事件輸出。 |
+| `ScoringService` | 記分、歷史堆疊與撤銷。 |
+| `WorkoutSessionManager` | HealthKit 授權、Workout session 生命週期。 |
+| `HapticsManager` | 統一觸覺回饋。 |
+| `PersistenceController` | 設定與比分 CSV 持久化。 |
+| `AppViewModel` | 串接所有服務，供 SwiftUI 視圖使用。 |
+
+## 主要畫面
+
+- `ScoreboardView`：顯示雙方比分、啟停比賽與主按鈕。
+- `SettingsView`：調整靈敏度、慣用手與資料儲存偏好。
+- `CalibrationView`：提示並執行手勢校準。
+
+## 建置與執行
+
+1. 於 Xcode 15+ 新建 watchOS App 專案，將 `WatchScorer/WatchScorer` 內的檔案加入 WatchKit Extension 目標。
+2. 啟用以下 Capabilities：
+   - Background Modes → Workout processing
+   - HealthKit（讀寫 Workout）
+   - App Group：`group.snapscorer`（或修改 `PersistenceController` 中的識別碼）
+3. 在 `Info.plist` 加入 `NSHealthShareUsageDescription` 與 `NSHealthUpdateUsageDescription`。
+4. 於實機 Apple Watch（Series 7 以上建議）建置並測試手勢偵測與校準流程。
+
+## 測試建議
+
+- 於模擬器驗證 UI 與設定流程。
+- 實機進行：
+  - 低活動期 precision ≥ 0.95, recall ≥ 0.90。
+  - 每 5 分鐘誤觸 ≤ 1 次。
+  - 比賽 1–2 小時電量消耗 < 10%/小時。
+
+## 授權
+
+本專案遵循原始 `LICENSE` 條款。

--- a/WatchScorer/WatchScorer/ContentView.swift
+++ b/WatchScorer/WatchScorer/ContentView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: AppViewModel
+    @State private var showingSettings = false
+    @State private var showingCalibration = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ScoreboardView(myScore: viewModel.playerScore,
+                           opponentScore: viewModel.opponentScore,
+                           isWorkoutActive: viewModel.isWorkoutActive,
+                           toggleWorkout: viewModel.toggleWorkoutSession,
+                           primaryIncrement: viewModel.incrementPlayer)
+                .padding(.horizontal, 12)
+
+            HStack {
+                Button(action: viewModel.incrementOpponent) {
+                    VStack {
+                        Text("對手 +1")
+                            .font(.headline)
+                        Text("雙次手勢")
+                            .font(.footnote)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button(action: viewModel.undoLastAction) {
+                    Image(systemName: "arrow.uturn.backward")
+                        .font(.title2)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!viewModel.canUndo)
+            }
+
+            HStack {
+                Button("設定") { showingSettings = true }
+                Button("校準") { showingCalibration = true }
+            }
+            .font(.footnote)
+        }
+        .padding()
+        .sheet(isPresented: $showingSettings) {
+            SettingsView(settings: viewModel.settings,
+                         applyAction: viewModel.updateSettings,
+                         dismiss: { showingSettings = false })
+        }
+        .sheet(isPresented: $showingCalibration) {
+            CalibrationView(calibrationState: viewModel.calibrationState,
+                            startAction: viewModel.startCalibration,
+                            finishAction: viewModel.finishCalibration,
+                            dismiss: { showingCalibration = false })
+        }
+        .onAppear { viewModel.onAppear() }
+        .primaryAction(viewModel.incrementPlayer)
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(AppViewModel(isPreview: true))
+}

--- a/WatchScorer/WatchScorer/Gesture/GestureEngine.swift
+++ b/WatchScorer/WatchScorer/Gesture/GestureEngine.swift
@@ -1,0 +1,88 @@
+import Combine
+import Foundation
+
+enum GestureEvent {
+    case player
+    case opponent
+}
+
+final class GestureEngine {
+    private var configuration: GestureSettings
+    private var rotationWindow: [(time: TimeInterval, value: Double)] = []
+    private var lastTriggerTime: TimeInterval?
+    private var pendingSingleTime: TimeInterval?
+    private var isPaused = false
+    private var orientationMultiplier: Double = 1
+
+    let eventPublisher = PassthroughSubject<GestureEvent, Never>()
+
+    init(configuration: GestureSettings) {
+        self.configuration = configuration
+    }
+
+    func updateConfiguration(_ configuration: GestureSettings) {
+        self.configuration = configuration
+        rotationWindow.removeAll(keepingCapacity: true)
+        pendingSingleTime = nil
+        lastTriggerTime = nil
+    }
+
+    func updateDominantWrist(_ wrist: DominantWrist) {
+        orientationMultiplier = wrist == .left ? -1 : 1
+    }
+
+    func pauseDetection(_ pause: Bool) {
+        isPaused = pause
+        if pause {
+            pendingSingleTime = nil
+        }
+    }
+
+    func process(_ sample: MotionSample) {
+        guard !isPaused else { return }
+
+        let adjustedRotation = sample.rotationRate * orientationMultiplier
+        rotationWindow.append((time: sample.timestamp, value: adjustedRotation))
+        trimWindow(before: sample.timestamp - configuration.lowActivityWindow)
+
+        let isLowActivity = computeVariance() < configuration.lowActivityVariance
+        let magnitude = abs(adjustedRotation)
+
+        if let pending = pendingSingleTime,
+           sample.timestamp - pending >= configuration.doubleMaxInterval {
+            pendingSingleTime = nil
+            eventPublisher.send(.player)
+            lastTriggerTime = sample.timestamp
+        }
+
+        guard isLowActivity else { return }
+        guard magnitude >= configuration.singleSnapThreshold else { return }
+
+        if let last = lastTriggerTime, sample.timestamp - last < configuration.refractoryPeriod {
+            return
+        }
+
+        if let pending = pendingSingleTime,
+           sample.timestamp - pending >= configuration.doubleMinInterval,
+           sample.timestamp - pending <= configuration.doubleMaxInterval {
+            pendingSingleTime = nil
+            lastTriggerTime = sample.timestamp
+            eventPublisher.send(.opponent)
+        } else {
+            pendingSingleTime = sample.timestamp
+        }
+    }
+
+    private func trimWindow(before cutoff: TimeInterval) {
+        while let first = rotationWindow.first, first.time < cutoff {
+            rotationWindow.removeFirst()
+        }
+    }
+
+    private func computeVariance() -> Double {
+        guard !rotationWindow.isEmpty else { return .greatestFiniteMagnitude }
+        let mean = rotationWindow.reduce(0) { $0 + $1.value } / Double(rotationWindow.count)
+        let variance = rotationWindow.reduce(0) { $0 + pow($1.value - mean, 2) } / Double(rotationWindow.count)
+        return variance
+    }
+}

--- a/WatchScorer/WatchScorer/Models/AppSettings.swift
+++ b/WatchScorer/WatchScorer/Models/AppSettings.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct AppSettings: Codable, Equatable {
+    var gesture: GestureSettings
+    var profile: ProfileSettings
+
+    static let `default` = AppSettings(gesture: .default, profile: .default)
+}
+
+struct GestureSettings: Codable, Equatable {
+    var singleSnapThreshold: Double
+    var lowActivityVariance: Double
+    var lowActivityWindow: TimeInterval
+    var doubleMinInterval: TimeInterval
+    var doubleMaxInterval: TimeInterval
+    var refractoryPeriod: TimeInterval
+    var sampleRate: Double
+
+    static let `default` = GestureSettings(singleSnapThreshold: 5.5,
+                                           lowActivityVariance: 0.15,
+                                           lowActivityWindow: 0.4,
+                                           doubleMinInterval: 0.6,
+                                           doubleMaxInterval: 0.9,
+                                           refractoryPeriod: 1.2,
+                                           sampleRate: 50)
+}
+
+struct ProfileSettings: Codable, Equatable {
+    var dominantWrist: DominantWrist
+    var storeToHealthKit: Bool
+    var persistLocally: Bool
+
+    static let `default` = ProfileSettings(dominantWrist: .right,
+                                           storeToHealthKit: true,
+                                           persistLocally: true)
+}
+
+enum DominantWrist: String, Codable, CaseIterable {
+    case left
+    case right
+
+    var label: String {
+        switch self {
+        case .left: return "左手"
+        case .right: return "右手"
+        }
+    }
+}

--- a/WatchScorer/WatchScorer/Motion/MotionStream.swift
+++ b/WatchScorer/WatchScorer/Motion/MotionStream.swift
@@ -1,0 +1,60 @@
+import Combine
+import CoreMotion
+import Foundation
+
+struct MotionSample {
+    let timestamp: TimeInterval
+    let rotationRate: Double
+    let userAccelerationMagnitude: Double
+}
+
+final class MotionStream {
+    private let motionManager = CMMotionManager()
+    private let queue = OperationQueue()
+    private(set) var sampleRate: Double
+    private let isPreview: Bool
+    private(set) var isRunning = false
+
+    let motionPublisher = PassthroughSubject<MotionSample, Never>()
+
+    init(sampleRate: Double, isPreview: Bool) {
+        self.sampleRate = sampleRate
+        self.isPreview = isPreview
+        queue.qualityOfService = .userInteractive
+    }
+
+    func start() {
+        guard !isPreview else { return }
+        guard !isRunning else { return }
+        guard motionManager.isDeviceMotionAvailable else { return }
+        motionManager.deviceMotionUpdateInterval = 1.0 / sampleRate
+        motionManager.startDeviceMotionUpdates(using: .xArbitraryCorrectedZVertical, to: queue) { [weak self] motion, _ in
+            guard let motion = motion else { return }
+            let sample = MotionSample(timestamp: motion.timestamp,
+                                      rotationRate: motion.rotationRate.x,
+                                      userAccelerationMagnitude: motion.userAcceleration.magnitude)
+            self?.motionPublisher.send(sample)
+        }
+        isRunning = true
+    }
+
+    func stop() {
+        guard !isPreview else { return }
+        motionManager.stopDeviceMotionUpdates()
+        isRunning = false
+    }
+
+    func update(sampleRate: Double) {
+        self.sampleRate = sampleRate
+        if motionManager.isDeviceMotionActive {
+            stop()
+            start()
+        }
+    }
+}
+
+private extension CMAcceleration {
+    var magnitude: Double {
+        sqrt(x * x + y * y + z * z)
+    }
+}

--- a/WatchScorer/WatchScorer/Services/HapticsManager.swift
+++ b/WatchScorer/WatchScorer/Services/HapticsManager.swift
@@ -1,0 +1,18 @@
+import WatchKit
+
+enum HapticEvent {
+    case single
+    case double
+}
+
+final class HapticsManager {
+    func play(_ event: HapticEvent) {
+        let device = WKInterfaceDevice.current()
+        switch event {
+        case .single:
+            device.play(.click)
+        case .double:
+            device.play(.directionUp)
+        }
+    }
+}

--- a/WatchScorer/WatchScorer/Services/ScoringService.swift
+++ b/WatchScorer/WatchScorer/Services/ScoringService.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum ScoreEvent: String, Codable {
+    case player
+    case opponent
+}
+
+struct ScoreSnapshot: Codable {
+    let timestamp: Date
+    let playerScore: Int
+    let opponentScore: Int
+}
+
+final class ScoringService: Codable {
+    private(set) var playerScore: Int = 0
+    private(set) var opponentScore: Int = 0
+
+    private var history: [ScoreEvent] = []
+
+    var canUndo: Bool {
+        !history.isEmpty
+    }
+
+    enum CodingKeys: CodingKey {
+        case playerScore
+        case opponentScore
+        case history
+    }
+
+    init() {}
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        playerScore = try container.decode(Int.self, forKey: .playerScore)
+        opponentScore = try container.decode(Int.self, forKey: .opponentScore)
+        history = try container.decode([ScoreEvent].self, forKey: .history)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(playerScore, forKey: .playerScore)
+        try container.encode(opponentScore, forKey: .opponentScore)
+        try container.encode(history, forKey: .history)
+    }
+
+    func record(_ event: ScoreEvent) {
+        switch event {
+        case .player:
+            playerScore += 1
+        case .opponent:
+            opponentScore += 1
+        }
+        history.append(event)
+    }
+
+    func undo() {
+        guard let last = history.popLast() else { return }
+        switch last {
+        case .player:
+            playerScore = max(playerScore - 1, 0)
+        case .opponent:
+            opponentScore = max(opponentScore - 1, 0)
+        }
+    }
+
+    func reset() {
+        playerScore = 0
+        opponentScore = 0
+        history.removeAll()
+    }
+
+    func applyPreviewScores() {
+        playerScore = 4
+        opponentScore = 3
+        history = Array(repeating: .player, count: 4) + Array(repeating: .opponent, count: 3)
+    }
+}

--- a/WatchScorer/WatchScorer/Services/WorkoutSessionManager.swift
+++ b/WatchScorer/WatchScorer/Services/WorkoutSessionManager.swift
@@ -1,0 +1,91 @@
+import Combine
+import HealthKit
+
+enum WorkoutSessionState {
+    case notStarted
+    case running
+    case ended
+}
+
+final class WorkoutSessionManager: NSObject {
+    private let healthStore = HKHealthStore()
+    private var session: HKWorkoutSession?
+    private var builder: HKLiveWorkoutBuilder?
+    private var shouldStoreToHealthKit = false
+
+    private let stateSubject = CurrentValueSubject<WorkoutSessionState, Never>(.notStarted)
+    var statePublisher: AnyPublisher<WorkoutSessionState, Never> { stateSubject.eraseToAnyPublisher() }
+
+    func requestAuthorizationIfNeeded() async {
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+        let readTypes: Set = [] as Set<HKObjectType>
+        let shareTypes: Set = [HKObjectType.workoutType()]
+        do {
+            try await healthStore.requestAuthorization(toShare: shareTypes, read: readTypes)
+        } catch {
+            print("HealthKit authorization failed: \(error)")
+        }
+    }
+
+    func startWorkout(storeToHealthKit: Bool) async throws {
+        guard session == nil else { return }
+
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .otherCombat
+        configuration.locationType = .indoor
+
+        session = try HKWorkoutSession(healthStore: healthStore, configuration: configuration)
+        builder = session?.associatedWorkoutBuilder()
+        builder?.dataSource = HKLiveWorkoutDataSource(healthStore: healthStore, workoutConfiguration: configuration)
+
+        session?.delegate = self
+        builder?.delegate = self
+
+        session?.startActivity(with: Date())
+        shouldStoreToHealthKit = storeToHealthKit
+        if shouldStoreToHealthKit {
+            builder?.beginCollection(withStart: Date()) { _, _ in }
+        }
+        stateSubject.send(.running)
+    }
+
+    func stopWorkout() async {
+        guard let session else { return }
+        session.end()
+        guard shouldStoreToHealthKit else {
+            stateSubject.send(.ended)
+            self.session = nil
+            self.builder = nil
+            self.shouldStoreToHealthKit = false
+            return
+        }
+
+        builder?.endCollection(withEnd: Date()) { [weak self] _, _ in
+            guard let self else { return }
+            self.builder?.finishWorkout { _, _ in }
+            self.stateSubject.send(.ended)
+            self.session = nil
+            self.builder = nil
+            self.shouldStoreToHealthKit = false
+        }
+    }
+}
+
+extension WorkoutSessionManager: HKWorkoutSessionDelegate {
+    func workoutSession(_ workoutSession: HKWorkoutSession, didChangeTo toState: HKWorkoutSessionState, from fromState: HKWorkoutSessionState, date: Date) {
+        if toState == .ended {
+            stateSubject.send(.ended)
+        }
+    }
+
+    func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error) {
+        print("Workout failed: \(error)")
+        stateSubject.send(.ended)
+    }
+}
+
+extension WorkoutSessionManager: HKLiveWorkoutBuilderDelegate {
+    func workoutBuilderDidCollectEvent(_ workoutBuilder: HKLiveWorkoutBuilder) {}
+
+    func workoutBuilder(_ workoutBuilder: HKLiveWorkoutBuilder, didCollect dataSources: Set<HKLiveWorkoutDataSource>) {}
+}

--- a/WatchScorer/WatchScorer/Utilities/PersistenceController.swift
+++ b/WatchScorer/WatchScorer/Utilities/PersistenceController.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+final class PersistenceController {
+    private let settingsURL: URL
+    private let scoreLogURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(fileManager: FileManager = .default) {
+        let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.snapscorer") ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        settingsURL = container.appendingPathComponent("settings.json")
+        scoreLogURL = container.appendingPathComponent("scores.csv")
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    }
+
+    func save(settings: AppSettings) {
+        do {
+            let data = try encoder.encode(settings)
+            try data.write(to: settingsURL, options: .atomic)
+        } catch {
+            print("Failed to save settings: \(error)")
+        }
+    }
+
+    func loadSettings() -> AppSettings? {
+        do {
+            let data = try Data(contentsOf: settingsURL)
+            return try decoder.decode(AppSettings.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    func persistScoresIfNeeded(_ scoring: ScoringService, enabled: Bool) {
+        guard enabled else { return }
+        let snapshot = "\(Date().iso8601String),\(scoring.playerScore),\(scoring.opponentScore)\n"
+        do {
+            if FileManager.default.fileExists(atPath: scoreLogURL.path) {
+                let handle = try FileHandle(forWritingTo: scoreLogURL)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                if let data = snapshot.data(using: .utf8) {
+                    try handle.write(contentsOf: data)
+                }
+            } else {
+                try snapshot.data(using: .utf8)?.write(to: scoreLogURL, options: .atomic)
+            }
+        } catch {
+            print("Failed to persist scores: \(error)")
+        }
+    }
+}
+
+private extension Date {
+    var iso8601String: String {
+        ISO8601DateFormatter().string(from: self)
+    }
+}

--- a/WatchScorer/WatchScorer/Utilities/View+PrimaryAction.swift
+++ b/WatchScorer/WatchScorer/Utilities/View+PrimaryAction.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+extension View {
+    /// Marks the view's primary action so that supported hardware gestures such as Double Tap can trigger it.
+    func primaryAction(_ action: @escaping () -> Void) -> some View {
+        accessibilityAction(.primaryAction, action)
+    }
+}

--- a/WatchScorer/WatchScorer/ViewModels/AppViewModel.swift
+++ b/WatchScorer/WatchScorer/ViewModels/AppViewModel.swift
@@ -1,0 +1,225 @@
+import Combine
+import CoreMotion
+import Foundation
+import HealthKit
+import SwiftUI
+
+@MainActor
+final class AppViewModel: ObservableObject {
+    @Published private(set) var playerScore = 0
+    @Published private(set) var opponentScore = 0
+    @Published private(set) var canUndo = false
+    @Published private(set) var isWorkoutActive = false
+    @Published private(set) var calibrationState = CalibrationState.idle
+    @Published private(set) var settings: AppSettings
+
+    private let motionStream: MotionStream
+    private let gestureEngine: GestureEngine
+    private let haptics = HapticsManager()
+    private let workoutManager = WorkoutSessionManager()
+    private let persistence = PersistenceController()
+    private let scoringService = ScoringService()
+
+    private var cancellables: Set<AnyCancellable> = []
+    private var calibrationSamples: [GestureCalibrationSample] = []
+    private var calibrationStreaming = false
+
+    init(isPreview: Bool = false) {
+        let storedSettings = persistence.loadSettings() ?? .default
+        settings = storedSettings
+        motionStream = MotionStream(sampleRate: storedSettings.gesture.sampleRate, isPreview: isPreview)
+        gestureEngine = GestureEngine(configuration: storedSettings.gesture)
+        gestureEngine.updateDominantWrist(storedSettings.profile.dominantWrist)
+
+        if isPreview {
+            scoringService.applyPreviewScores()
+        }
+
+        refreshScores()
+
+        bindStreams()
+    }
+
+    func onAppear() {
+        Task {
+            await workoutManager.requestAuthorizationIfNeeded()
+        }
+    }
+
+    func incrementPlayer() {
+        scoringService.record(.player)
+        refreshScores()
+        haptics.play(.single)
+    }
+
+    func incrementOpponent() {
+        scoringService.record(.opponent)
+        refreshScores()
+        haptics.play(.double)
+    }
+
+    func undoLastAction() {
+        scoringService.undo()
+        refreshScores()
+    }
+
+    func toggleWorkoutSession() {
+        Task {
+            if isWorkoutActive {
+                await workoutManager.stopWorkout()
+                stopMotion()
+            } else {
+                do {
+                    try await workoutManager.startWorkout(storeToHealthKit: settings.profile.storeToHealthKit)
+                    startMotion()
+                } catch {
+                    print("Failed to start workout: \(error)")
+                }
+            }
+        }
+    }
+
+    func updateSettings(_ settings: AppSettings) {
+        self.settings = settings
+        gestureEngine.updateConfiguration(settings.gesture)
+        gestureEngine.updateDominantWrist(settings.profile.dominantWrist)
+        motionStream.update(sampleRate: settings.gesture.sampleRate)
+        persistence.save(settings: settings)
+    }
+
+    func startCalibration() {
+        calibrationSamples = []
+        calibrationState = .recording
+        gestureEngine.pauseDetection(true)
+        if !motionStream.isRunning {
+            motionStream.start()
+            calibrationStreaming = true
+        }
+    }
+
+    func finishCalibration() {
+        defer {
+            if calibrationStreaming && !isWorkoutActive {
+                motionStream.stop()
+            }
+            calibrationStreaming = false
+        }
+
+        guard calibrationState == .recording else {
+            calibrationState = .idle
+            gestureEngine.pauseDetection(false)
+            return
+        }
+
+        let analyzer = CalibrationAnalyzer()
+        let result = analyzer.deriveSettings(from: calibrationSamples)
+        var updatedSettings = settings
+        if let single = result.singleThreshold {
+            updatedSettings.gesture.singleSnapThreshold = single
+        }
+        if let variance = result.variance {
+            updatedSettings.gesture.lowActivityVariance = variance
+        }
+        settings = updatedSettings
+        gestureEngine.updateConfiguration(updatedSettings.gesture)
+        persistence.save(settings: updatedSettings)
+        calibrationState = .completed
+        gestureEngine.pauseDetection(false)
+    }
+
+    private func startMotion() {
+        guard !isWorkoutActive else { return }
+        isWorkoutActive = true
+        motionStream.start()
+    }
+
+    private func stopMotion() {
+        guard isWorkoutActive else { return }
+        isWorkoutActive = false
+        motionStream.stop()
+        persistence.persistScoresIfNeeded(scoringService, enabled: settings.profile.persistLocally)
+    }
+
+    private func bindStreams() {
+        motionStream.motionPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sample in
+                guard let self else { return }
+                if calibrationState == .recording {
+                    calibrationSamples.append(GestureCalibrationSample(timestamp: sample.timestamp,
+                                                                       rotationRate: sample.rotationRate,
+                                                                       userAccelerationMagnitude: sample.userAccelerationMagnitude))
+                }
+                gestureEngine.process(sample)
+            }
+            .store(in: &cancellables)
+
+        gestureEngine.eventPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                guard let self else { return }
+                switch event {
+                case .player:
+                    scoringService.record(.player)
+                    refreshScores()
+                    haptics.play(.single)
+                case .opponent:
+                    scoringService.record(.opponent)
+                    refreshScores()
+                    haptics.play(.double)
+                }
+            }
+            .store(in: &cancellables)
+
+        workoutManager.statePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self else { return }
+                if state == .ended {
+                    stopMotion()
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func refreshScores() {
+        playerScore = scoringService.playerScore
+        opponentScore = scoringService.opponentScore
+        canUndo = scoringService.canUndo
+    }
+}
+
+// MARK: - Calibration support
+
+struct GestureCalibrationSample {
+    let timestamp: TimeInterval
+    let rotationRate: Double
+    let userAccelerationMagnitude: Double
+}
+
+enum CalibrationState {
+    case idle
+    case recording
+    case completed
+}
+
+struct CalibrationResult {
+    let singleThreshold: Double?
+    let variance: Double?
+}
+
+struct CalibrationAnalyzer {
+    func deriveSettings(from samples: [GestureCalibrationSample]) -> CalibrationResult {
+        guard !samples.isEmpty else { return CalibrationResult(singleThreshold: nil, variance: nil) }
+
+        let magnitudes = samples.map { abs($0.rotationRate) }
+        let sorted = magnitudes.sorted()
+        let percentileIndex = max(Int(Double(sorted.count) * 0.7) - 1, 0)
+        let threshold = sorted[percentileIndex]
+
+        let rotationMean = samples.reduce(0) { $0 + $1.rotationRate } / Double(samples.count)
+        let variance = samples.reduce(0) { $0 + pow($1.rotationRate - rotationMean, 2) } / Double(samples.count)
+
+        return CalibrationResult(singleThreshold: threshold, variance: variance)
+    }
+}

--- a/WatchScorer/WatchScorer/Views/CalibrationView.swift
+++ b/WatchScorer/WatchScorer/Views/CalibrationView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct CalibrationView: View {
+    let calibrationState: CalibrationState
+    let startAction: () -> Void
+    let finishAction: () -> Void
+    let dismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("校準手勢")
+                .font(.headline)
+            Text(instructionText)
+                .multilineTextAlignment(.center)
+                .font(.footnote)
+
+            if calibrationState == .recording {
+                ProgressView()
+                Button("完成", action: finishAction)
+                    .buttonStyle(.borderedProminent)
+            } else {
+                Button("開始錄製") {
+                    startAction()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+            Button("關閉") {
+                if calibrationState == .recording {
+                    finishAction()
+                }
+                dismiss()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+    }
+
+    private var instructionText: String {
+        switch calibrationState {
+        case .idle:
+            return "請進行 10 次單 snap 與 10 次雙 snap。錄製期間請保持手腕自然姿勢，完成後按下完成。"
+        case .recording:
+            return "偵測中… 請依指示完成手勢。"
+        case .completed:
+            return "已更新個人化參數，可隨時重新校準。"
+        }
+    }
+}
+
+#Preview {
+    CalibrationView(calibrationState: .idle,
+                    startAction: {},
+                    finishAction: {},
+                    dismiss: {})
+}

--- a/WatchScorer/WatchScorer/Views/ScoreboardView.swift
+++ b/WatchScorer/WatchScorer/Views/ScoreboardView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct ScoreboardView: View {
+    let myScore: Int
+    let opponentScore: Int
+    let isWorkoutActive: Bool
+    let toggleWorkout: () -> Void
+    let primaryIncrement: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Snap 計分")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            HStack(alignment: .center) {
+                VStack {
+                    Text("我方")
+                        .font(.caption2)
+                    Text("\(myScore)")
+                        .font(.system(size: 44, weight: .bold))
+                        .contentTransition(.numericText())
+                }
+                .frame(maxWidth: .infinity)
+
+                Button(action: primaryIncrement) {
+                    VStack(spacing: 4) {
+                        Text("+1")
+                            .font(.title2)
+                        Text("主手勢")
+                            .font(.caption2)
+                    }
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityLabel("我方加一分")
+                .accessibilityHint("單次腕部微動")
+
+                VStack {
+                    Text("對手")
+                        .font(.caption2)
+                    Text("\(opponentScore)")
+                        .font(.system(size: 44, weight: .bold))
+                        .contentTransition(.numericText())
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            Button(action: toggleWorkout) {
+                Label(isWorkoutActive ? "結束比賽" : "開始比賽",
+                      systemImage: isWorkoutActive ? "stop.circle" : "play.circle")
+            }
+            .buttonStyle(.bordered)
+            .tint(isWorkoutActive ? .red : .green)
+        }
+    }
+}
+
+#Preview {
+    ScoreboardView(myScore: 3,
+                   opponentScore: 2,
+                   isWorkoutActive: true,
+                   toggleWorkout: {},
+                   primaryIncrement: {})
+}

--- a/WatchScorer/WatchScorer/Views/SettingsView.swift
+++ b/WatchScorer/WatchScorer/Views/SettingsView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var settings: AppSettings
+    let applyAction: (AppSettings) -> Void
+    let dismiss: () -> Void
+
+    init(settings: AppSettings,
+         applyAction: @escaping (AppSettings) -> Void,
+         dismiss: @escaping () -> Void) {
+        _settings = State(initialValue: settings)
+        self.applyAction = applyAction
+        self.dismiss = dismiss
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("靈敏度") {
+                    Slider(value: $settings.gesture.singleSnapThreshold,
+                           in: 3 ... 9,
+                           step: 0.1) {
+                        Text("主手勢閾值")
+                    } minimumValueLabel: {
+                        Text("低")
+                    } maximumValueLabel: {
+                        Text("高")
+                    }
+
+                    Slider(value: $settings.gesture.lowActivityVariance,
+                           in: 0.01 ... 1.5,
+                           step: 0.01) {
+                        Text("低活動門檻")
+                    } minimumValueLabel: {
+                        Text("敏感")
+                    } maximumValueLabel: {
+                        Text("嚴格")
+                    }
+                }
+
+                Section("手別") {
+                    Picker("慣用手", selection: $settings.profile.dominantWrist) {
+                        ForEach(DominantWrist.allCases, id: \.self) { wrist in
+                            Text(wrist.label).tag(wrist)
+                        }
+                    }
+                }
+
+                Section("資料") {
+                    Toggle("儲存至 HealthKit", isOn: $settings.profile.storeToHealthKit)
+                    Toggle("記錄 CSV", isOn: $settings.profile.persistLocally)
+                }
+            }
+            .navigationTitle("設定")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("關閉", action: dismiss)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("套用") {
+                        applyAction(settings)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView(settings: .default,
+                 applyAction: { _ in },
+                 dismiss: {})
+}

--- a/WatchScorer/WatchScorer/WatchScorerApp.swift
+++ b/WatchScorer/WatchScorer/WatchScorerApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct WatchScorerApp: App {
+    @StateObject private var appViewModel = AppViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appViewModel)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI-based Apple Watch snap scoring app structure with gesture-driven scoreboard, settings, and calibration flows
- implement motion streaming, gesture detection, scoring, workout session, haptics, and persistence services to meet background processing and data retention goals
- document build, capability, and testing guidance in the README for integrating the modules into an Xcode watchOS project

## Testing
- not run (watchOS project structure only)


------
https://chatgpt.com/codex/tasks/task_e_68cc4a0fd648832982e0d0dcb9d3f378